### PR TITLE
Add Google Sign-In sample

### DIFF
--- a/SpalshScreen/AndroidManifest.xml
+++ b/SpalshScreen/AndroidManifest.xml
@@ -18,6 +18,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".SignInActivity"
+            android:label="@string/app_name" />
     </application>
 
 </manifest>

--- a/SpalshScreen/res/layout/activity_sign_in.xml
+++ b/SpalshScreen/res/layout/activity_sign_in.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical" >
+
+    <com.google.android.gms.common.SignInButton
+        android:id="@+id/sign_in_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/SpalshScreen/res/values/strings.xml
+++ b/SpalshScreen/res/values/strings.xml
@@ -3,5 +3,6 @@
 
     <string name="hello">Hello World, SpalshScreenActivity!</string>
     <string name="app_name">SpalshScreen</string>
+    <string name="sign_in">Sign in with Google</string>
 
 </resources>

--- a/SpalshScreen/src/com/fancy/splashscreen/SignInActivity.java
+++ b/SpalshScreen/src/com/fancy/splashscreen/SignInActivity.java
@@ -1,0 +1,75 @@
+package com.fancy.splashscreen;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.Toast;
+
+// Google Sign-In imports. These classes are part of the
+// Google Play services auth library.
+import com.google.android.gms.auth.api.signin.GoogleSignIn;
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
+import com.google.android.gms.auth.api.signin.GoogleSignInClient;
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
+import com.google.android.gms.common.SignInButton;
+import com.google.android.gms.common.api.ApiException;
+import com.google.android.gms.tasks.Task;
+
+public class SignInActivity extends Activity {
+
+    private static final int RC_SIGN_IN = 9001;
+
+    private GoogleSignInClient mGoogleSignInClient;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_sign_in);
+
+        // Configure sign-in to request the user's ID, email address, and basic profile.
+        GoogleSignInOptions gso = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                .requestEmail()
+                .build();
+
+        // Build a GoogleSignInClient with the options specified by gso.
+        mGoogleSignInClient = GoogleSignIn.getClient(this, gso);
+
+        // Set the dimensions of the sign-in button.
+        SignInButton signInButton = findViewById(R.id.sign_in_button);
+        signInButton.setSize(SignInButton.SIZE_STANDARD);
+        signInButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                signIn();
+            }
+        });
+    }
+
+    private void signIn() {
+        Intent signInIntent = mGoogleSignInClient.getSignInIntent();
+        startActivityForResult(signInIntent, RC_SIGN_IN);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == RC_SIGN_IN) {
+            Task<GoogleSignInAccount> task = GoogleSignIn.getSignedInAccountFromIntent(data);
+            handleSignInResult(task);
+        }
+    }
+
+    private void handleSignInResult(Task<GoogleSignInAccount> completedTask) {
+        try {
+            GoogleSignInAccount account = completedTask.getResult(ApiException.class);
+            if (account != null) {
+                Toast.makeText(this, "Signed in as " + account.getDisplayName(), Toast.LENGTH_LONG).show();
+            }
+        } catch (ApiException e) {
+            Toast.makeText(this, "Sign in failed", Toast.LENGTH_LONG).show();
+        }
+    }
+}

--- a/SpalshScreen/src/com/fancy/splashscreen/SpalshScreenActivity.java
+++ b/SpalshScreen/src/com/fancy/splashscreen/SpalshScreenActivity.java
@@ -8,6 +8,8 @@ import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.content.Intent;
+import android.os.Handler;
 
 public class SpalshScreenActivity extends Activity {
 	 public void onAttachedToWindow() {
@@ -34,9 +36,15 @@ public class SpalshScreenActivity extends Activity {
         ImageView iv = (ImageView) findViewById(R.id.logo);
         iv.clearAnimation();
         iv.startAnimation(anim);
-        
-        
-        
+
+        // After the splash animations, launch the sign-in activity.
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                startActivity(new Intent(SpalshScreenActivity.this, SignInActivity.class));
+                finish();
+            }
+        }, 3000);
     }
-   
+
 }


### PR DESCRIPTION
## Summary
- add a new `SignInActivity` demonstrating Google Sign-In
- start `SignInActivity` from the splash screen after the animations
- include a layout for the Google Sign-In button
- register the new activity in the manifest
- add a string resource for sign-in

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6840586e4368832a844468426c164ad3